### PR TITLE
[ACCSEC-21700] - Improve readability for network errors

### DIFF
--- a/TwilioVerifySDK/TwilioVerify/Sources/Extensions/URLSession+Extensions.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/Extensions/URLSession+Extensions.swift
@@ -47,9 +47,3 @@ extension URLSession {
     }
   }
 }
-
-internal struct FailureResponse {
-  let responseCode: Int
-  let errorData: Data
-  let headers: [AnyHashable: Any]
-}

--- a/TwilioVerifySDK/TwilioVerify/Sources/Networking/Models/Response.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/Networking/Models/Response.swift
@@ -23,3 +23,13 @@ public struct Response {
   let data: Data
   let headers: [AnyHashable: Any]
 }
+
+public struct FailureResponse {
+  let responseCode: Int
+  let errorData: Data
+  let headers: [AnyHashable: Any]
+
+  var errorDescription: String {
+    return String(data: errorData, encoding: .utf8) ?? String()
+  }
+}

--- a/TwilioVerifySDK/TwilioVerify/Sources/TwilioVerifyError.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/TwilioVerifyError.swift
@@ -65,8 +65,15 @@ public enum TwilioVerifyError: LocalizedError {
   ///Brief description of the error, indicates at which layer the error ocurred
   public var errorDescription: String? {
     switch self {
-      case .networkError:
-        return "Error while calling the API"
+      case .networkError(let error):
+        var description = ["Error while calling the API"]
+
+        if case let .failureStatusCode(failureResponse) = (error as? TwilioVerifyError)?.originalError as? NetworkError,
+           !failureResponse.errorDescription.isEmpty {
+          description.append(failureResponse.errorDescription)
+        }
+
+        return description.compactMap { $0 }.joined(separator: ": ")
       case .mapperError:
         return "Error while mapping an entity"
       case .storageError:

--- a/TwilioVerifySDKTests/TwilioVerify/Sources/Domain/Challenge/ChallengeFacadeTests.swift
+++ b/TwilioVerifySDKTests/TwilioVerify/Sources/Domain/Challenge/ChallengeFacadeTests.swift
@@ -271,6 +271,46 @@ class ChallengeFacadeTests: XCTestCase {
     XCTAssertEqual(error.localizedDescription, expectedError.localizedDescription,
                    "Error description should be \(expectedError.localizedDescription) but was \(error.localizedDescription)")
   }
+
+  func testGetAllChallenges_withCompleteFailureResponse_shouldFailAndRetrieveNetworkDescription() {
+    let expectation = self.expectation(description: "testGetAllChallenges_withFailureResponse_shouldFail")
+    factorFacade.factor = Constants.expectedFactor
+    let expectedError =  TwilioVerifyError.networkError(error: NetworkError.failureStatusCode(failureResponse: FailureResponse(responseCode: 400,
+                                                                                                                               errorData: "{\"message\":\"Bad Request\"}".data(using: .utf8)!,
+                                                                                                                               headers: [:])) as NSError)
+    repository.error = expectedError
+    var error: TwilioVerifyError!
+    challengeFacade.getAll(withPayload: Constants.challengeListPayload, success: { _ in
+      XCTFail()
+      expectation.fulfill()
+    }) { failure in
+      error = failure
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 3, handler: nil)
+    XCTAssertEqual(error.code, expectedError.code, "Error code should be \(expectedError.code) but was \(error.code)")
+    XCTAssertEqual(error.localizedDescription, "Error while calling the API: {\"message\":\"Bad Request\"}")
+  }
+
+  func testGetAllChallenges_withFailureResponse_shouldFailAndRetrieveGenericNetworkDescription() {
+    let expectation = self.expectation(description: "testGetAllChallenges_withFailureResponse_shouldFail")
+    factorFacade.factor = Constants.expectedFactor
+    let expectedError =  TwilioVerifyError.networkError(error: NetworkError.failureStatusCode(failureResponse: FailureResponse(responseCode: 400,
+                                                                                                                               errorData: "".data(using: .utf8)!,
+                                                                                                                               headers: [:])) as NSError)
+    repository.error = expectedError
+    var error: TwilioVerifyError!
+    challengeFacade.getAll(withPayload: Constants.challengeListPayload, success: { _ in
+      XCTFail()
+      expectation.fulfill()
+    }) { failure in
+      error = failure
+      expectation.fulfill()
+    }
+    waitForExpectations(timeout: 3, handler: nil)
+    XCTAssertEqual(error.code, expectedError.code, "Error code should be \(expectedError.code) but was \(error.code)")
+    XCTAssertEqual(error.localizedDescription, "Error while calling the API")
+  }
 }
 
 private extension ChallengeFacadeTests {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,7 @@
 output_directory = './fastlane/Test Output/'
 coverage_directory = '/coverage'
 complete_suite = 'CompleteSuite'
-single_ftl_device = [{ios_model_id: 'iphone8', ios_version_id: '14.1'}]
+single_ftl_device = [{ios_model_id: 'iphone8', ios_version_id: '13.6'}]
 all_ftl_devices = [
   {ios_model_id: 'iphone11', ios_version_id: '13.6'},
   {ios_model_id: 'iphone11pro', ios_version_id: '13.3'},

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,7 @@
 output_directory = './fastlane/Test Output/'
 coverage_directory = '/coverage'
 complete_suite = 'CompleteSuite'
-single_ftl_device = [{ios_model_id: 'iphone8', ios_version_id: '13.6'}]
+single_ftl_device = [{ios_model_id: 'iphone8', ios_version_id: '14.1'}]
 all_ftl_devices = [
   {ios_model_id: 'iphone11', ios_version_id: '13.6'},
   {ios_model_id: 'iphone11pro', ios_version_id: '13.3'},


### PR DESCRIPTION
<!-- Ticket: Please add the Jira ticket number or the Github issue number according to your case -->
## Jira Ticket
- ACCSEC-21700

## Github Issue
- ISSUE-

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->
## Description

- Make FailureResponse public.
- Provide full errorDescription for TwilioVerifyErrors that were originated by a NetworkError.

<!-- Commit message: This repository uses a commit message convention https://docs.google.com/document/d/19ed9FHIAlJwlGzf3xacgE15MVfTwx8n9G2QeYyCr-5E/edit?usp=drive_web&ouid=116864038767072405931 set the commit message to be used when merging this PR e.g. docs: add architecture diagrams [ACCSEC-99999] -->
## Commit message
-  feat: Improve network errors readability

<!-- Screenshot: When possible add a screenshot or gif showing your changes if not you can remove this section -->
## Screenshot

<!-- Testing: Please check all that apply -->
## Testing
- [ ] Added unit tests
- [ ] Ran unit tests successfully
- [ ] Added documentation for public APIs and/or Wiki
