### PR TITLE
[ACCSEC-21820][Fix] Fixed crash when casting NSError in iOS versions prior 14

### DIFF
--- a/TwilioVerifySDK/TwilioVerify/Sources/TwilioVerifyError.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/TwilioVerifyError.swift
@@ -68,7 +68,7 @@ public enum TwilioVerifyError: LocalizedError {
       case .networkError(let error):
         var description = ["Error while calling the API"]
 
-        if case let .failureStatusCode(failureResponse) = (error as? TwilioVerifyError)?.originalError as? NetworkError,
+        if case let .failureStatusCode(failureResponse) = ((error as Error) as? TwilioVerifyError)?.originalError as? NetworkError,
            !failureResponse.errorDescription.isEmpty {
           description.append(failureResponse.errorDescription)
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Twilio Verify. Please consider this template for your PR -->
<!-- Title format: [Ticket Number/Issue Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (task, bug, housekeeping, etc) -->


<!-- Ticket: Please add the Jira ticket number or the Github issue number according to your case -->
## Jira Ticket
- ACCSEC-21820

## Github Issue
n/a

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->
## Description
- I did cast the `NSError` to a Swift `Error` before being casted to a `TwilioVerifyError`. With this approach we can prevent that the `NSError` get released automatically. 

<!-- Commit message: This repository uses a commit message convention https://docs.google.com/document/d/19ed9FHIAlJwlGzf3xacgE15MVfTwx8n9G2QeYyCr-5E/edit?usp=drive_web&ouid=116864038767072405931 set the commit message to be used when merging this PR e.g. docs: add architecture diagrams [ACCSEC-99999] -->
## Commit message
-  

<!-- Screenshot: When possible add a screenshot or gif showing your changes if not you can remove this section -->
## Screenshot

![image](https://user-images.githubusercontent.com/14830877/129414446-ee2f0a2e-8538-44d5-9fd7-075ab6ff68ea.png)


<!-- Testing: Please check all that apply -->
## Testing
- [ ] Added unit tests
- [X] Ran unit tests successfully
- [ ] Added documentation for public APIs and/or Wiki
