### PR TITLE
[ACCSEC-22227] - Manage biometric authentication errors.

### DIFF
--- a/TwilioVerifySDK.xcodeproj/project.pbxproj
+++ b/TwilioVerifySDK.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		20E5157D24A3B3A700A467FC /* ChallengeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E5157C24A3B3A700A467FC /* ChallengeDTO.swift */; };
 		20E5158024A3BBC800A467FC /* ChallengeMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E5157F24A3BBC800A467FC /* ChallengeMapperTests.swift */; };
 		20EAB647248E94EC00BCD8CD /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EAB646248E94EC00BCD8CD /* DateFormatter+Extensions.swift */; };
+		86902FB726F8E4EB00DD72E1 /* BiometricError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86902FB626F8E4EB00DD72E1 /* BiometricError.swift */; };
 		86E5DD5326F1413000A5680B /* AuthenticatedSecureStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E5DD5226F1413000A5680B /* AuthenticatedSecureStorageTests.swift */; };
 		86E5DD5B26F2892E00A5680B /* MockContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E5DD5A26F2892E00A5680B /* MockContext.swift */; };
 		86E5DD5D26F2895600A5680B /* AuthenticatorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E5DD5C26F2895600A5680B /* AuthenticatorMock.swift */; };
@@ -274,6 +275,7 @@
 		20E5157C24A3B3A700A467FC /* ChallengeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeDTO.swift; sourceTree = "<group>"; };
 		20E5157F24A3BBC800A467FC /* ChallengeMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeMapperTests.swift; sourceTree = "<group>"; };
 		20EAB646248E94EC00BCD8CD /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
+		86902FB626F8E4EB00DD72E1 /* BiometricError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricError.swift; sourceTree = "<group>"; };
 		86E5DD5226F1413000A5680B /* AuthenticatedSecureStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedSecureStorageTests.swift; sourceTree = "<group>"; };
 		86E5DD5A26F2892E00A5680B /* MockContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockContext.swift; sourceTree = "<group>"; };
 		86E5DD5C26F2895600A5680B /* AuthenticatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatorMock.swift; sourceTree = "<group>"; };
@@ -682,6 +684,14 @@
 			path = Challenge;
 			sourceTree = "<group>";
 		};
+		86902FB526F8E4D600DD72E1 /* Biometrics */ = {
+			isa = PBXGroup;
+			children = (
+				86902FB626F8E4EB00DD72E1 /* BiometricError.swift */,
+			);
+			path = Biometrics;
+			sourceTree = "<group>";
+		};
 		86E5DD5926F2890800A5680B /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -913,6 +923,7 @@
 		F27A33F524CF89DB00A8053D /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				86902FB526F8E4D600DD72E1 /* Biometrics */,
 				F27A33F824CF89F000A8053D /* Storage */,
 				F27A33F724CF89E900A8053D /* Keychain */,
 				F27A33F624CF89E400A8053D /* Key */,
@@ -1262,6 +1273,7 @@
 				F2C552BD2493E34A006F6CDF /* FactorFacade.swift in Sources */,
 				F2572054256EAC5B0026963E /* DefaultLogger.swift in Sources */,
 				F02034CB24F9654C00D87AAA /* FactorMigrations.swift in Sources */,
+				86902FB726F8E4EB00DD72E1 /* BiometricError.swift in Sources */,
 				20793D6B25C1E19B00870D2C /* TwilioVerifyConfig.swift in Sources */,
 				2093572724870CAF008FDBCC /* VerifyFactorPayload.swift in Sources */,
 				F0261C4424A263F1007881E9 /* APIConstants.swift in Sources */,

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Biometrics/BiometricError.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Biometrics/BiometricError.swift
@@ -1,0 +1,54 @@
+//
+//  BiometricError.swift
+//  TwilioVerifySDK
+//
+//  Created by Alejandro Orozco Builes on 17/09/21.
+//  Copyright © 2021 Twilio. All rights reserved.
+//
+
+import Foundation
+import LocalAuthentication
+
+public enum BiometricError: Error, LocalizedError {
+
+    // MARK: - Biometric LAError cases
+
+    case appCancel
+    case authenticationFailed
+    case invalidContext
+    case notInteractive
+    case passcodeNotSet
+    case systemCancel
+    case userCancel
+    case userFallback
+    case biometryLockout
+    case biometryNotAvailable
+    case biometryNotEnrolled
+
+    public var errorDescription: String? {
+        return "Biometric error: LAError \(String(describing: self))"
+    }
+
+    // MARK: - Resolution
+
+    public static func given(_ error: NSError?) -> Self? {
+      guard let error = error else {
+        return nil
+      }
+
+      switch LAError.Code(rawValue: error.code) {
+        case .appCancel: return .appCancel
+        case .authenticationFailed: return .authenticationFailed
+        case .invalidContext: return .invalidContext
+        case .notInteractive: return .notInteractive
+        case .passcodeNotSet: return .passcodeNotSet
+        case .systemCancel: return .systemCancel
+        case .userCancel: return .userCancel
+        case .userFallback: return .userFallback
+        case .biometryLockout: return .biometryLockout
+        case .biometryNotAvailable: return .biometryNotAvailable
+        case .biometryNotEnrolled: return .biometryNotEnrolled
+        default: return nil
+        }
+    }
+}

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Biometrics/BiometricError.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Biometrics/BiometricError.swift
@@ -9,6 +9,7 @@
 import Foundation
 import LocalAuthentication
 
+/// Biometric Errors derived by LAError's LocalAuthentication. For more information, see https://developer.apple.com/documentation/localauthentication/laerror
 public enum BiometricError: Error, LocalizedError {
 
     // MARK: - Biometric LAError cases
@@ -31,6 +32,7 @@ public enum BiometricError: Error, LocalizedError {
 
     // MARK: - Resolution
 
+    // swiftlint:disable:next cyclomatic_complexity
     public static func given(_ error: NSError?) -> Self? {
       guard let error = error else {
         return nil

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Storage/AuthenticatedSecureStorage.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Storage/AuthenticatedSecureStorage.swift
@@ -41,7 +41,7 @@ public class AuthenticatedSecureStorage {
 
     public var errorDescription: String? {
       switch self {
-      case .authenticationFailed: return "Authentication failed"
+        case .authenticationFailed: return "Authentication failed"
       }
     }
   }

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Storage/AuthenticatedSecureStorage.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Storage/AuthenticatedSecureStorage.swift
@@ -36,12 +36,12 @@ public protocol AuthenticatedSecureStorageProvider {
 ///:nodoc:
 public class AuthenticatedSecureStorage {
 
-  private enum Errors: Error, LocalizedError {
-    case authenticationFailed
+  public enum Errors: Error, LocalizedError {
+    case authenticationFailed(Error?)
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
       switch self {
-        case .authenticationFailed: return "Authentication failed"
+      case .authenticationFailed: return "Authentication failed"
       }
     }
   }
@@ -131,7 +131,23 @@ extension AuthenticatedSecureStorage: AuthenticatedSecureStorageProvider {
   }
 
   private func evaluatePolicy(for authenticator: Authenticator, success: @escaping EmptySuccessBlock, failure: @escaping ErrorBlock) {
-    Logger.shared.log(withLevel: .info, message: "Evaluating authentication")
+    Logger.shared.log(withLevel: .info, message: "Validating policy")
+
+    var error: NSError?
+
+    guard authenticator.context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+      if let biometricError = BiometricError.given(error) {
+        Logger.shared.log(withLevel: .error, message: biometricError.localizedDescription)
+        failure(biometricError)
+      } else {
+        Logger.shared.log(withLevel: .error, message: error?.localizedDescription ?? .init())
+        failure(Errors.authenticationFailed(error))
+      }
+      return
+    }
+
+    Logger.shared.log(withLevel: .info, message: "Evaluating policy")
+
     authenticator.context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: authenticator.localizedReason) { result, err in
       if result {
         success()
@@ -140,7 +156,7 @@ extension AuthenticatedSecureStorage: AuthenticatedSecureStorageProvider {
           Logger.shared.log(withLevel: .error, message: error.localizedDescription)
           failure(error)
         } else {
-          let error = Errors.authenticationFailed
+          let error = Errors.authenticationFailed(error)
           Logger.shared.log(withLevel: .error, message: error.localizedDescription)
           failure(error)
         }

--- a/TwilioVerifySDKTests/TwilioSecurity/Sources/Storage/AuthenticatedSecureStorageTests.swift
+++ b/TwilioVerifySDKTests/TwilioSecurity/Sources/Storage/AuthenticatedSecureStorageTests.swift
@@ -239,4 +239,44 @@ class AuthenticatedSecureStorageTests: XCTestCase {
     // Then
     XCTAssertEqual(keychainMock.callOrder.first, .deleteItem)
   }
+
+  // MARK: - Biometric Errors
+
+  func testSave_withValidValuesSavingDataButFailedAuthentication_shouldThrowBiometricError() {
+    // Given
+    let data = "testData".data(using: .utf8)
+    let key = "testKey"
+    let mockContext = MockContext()
+    let authenticator = AuthenticatorMock(context: mockContext)
+    let expectedError = "Biometric error: LAError authenticationFailed"
+    mockContext.canEvaluatePolicyResult = false
+    mockContext.canEvaluatePolicyError = LAError(.authenticationFailed)
+
+    // When
+    testSubject.save(data!, withKey: key, authenticator: authenticator) {
+      // Then
+      XCTFail("Save data should fail, since there is not keychain available")
+    } failure: { error in
+      XCTAssertEqual(expectedError, error.localizedDescription)
+    }
+  }
+
+  func testSave_withValidValuesSavingDataButUnexpectedError_shouldThrowUnexpectedError() {
+    // Given
+    let data = "testData".data(using: .utf8)
+    let key = "testKey"
+    let mockContext = MockContext()
+    let authenticator = AuthenticatorMock(context: mockContext)
+    let expectedError = "Authentication failed"
+    mockContext.canEvaluatePolicyResult = false
+    mockContext.canEvaluatePolicyError = MockErrors.unexpected
+
+    // When
+    testSubject.save(data!, withKey: key, authenticator: authenticator) {
+      // Then
+      XCTFail("Save data should fail, since there is not keychain available")
+    } failure: { error in
+      XCTAssertEqual(expectedError, error.localizedDescription)
+    }
+  }
 }

--- a/TwilioVerifySDKTests/TwilioSecurity/Sources/Storage/Mocks/MockContext.swift
+++ b/TwilioVerifySDKTests/TwilioSecurity/Sources/Storage/Mocks/MockContext.swift
@@ -23,6 +23,8 @@ class MockContext: LAContext {
 
   var evaluatePolicyResult: Bool = true
   var evaluatePolicyError: Error?
+  var canEvaluatePolicyResult: Bool = true
+  var canEvaluatePolicyError: Error?
 
   convenience init(evaluatePolicyResult: Bool = true, evaluatePolicyError: Error? = nil) {
     self.init()
@@ -31,7 +33,8 @@ class MockContext: LAContext {
   }
 
   override func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool {
-    return true
+    error?.pointee = canEvaluatePolicyError as NSError?
+    return canEvaluatePolicyResult
   }
 
   override func evaluatePolicy(_ policy: LAPolicy, localizedReason: String, reply: @escaping (Bool, Error?) -> Void) {


### PR DESCRIPTION


<!-- Thanks for contributing to Twilio Verify. Please consider this template for your PR -->
<!-- Title format: [Ticket Number/Issue Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (task, bug, housekeeping, etc) -->


<!-- Ticket: Please add the Jira ticket number or the Github issue number according to your case -->
## Jira Ticket
ACCSEC-22227

## Github Issue
- ISSUE-

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->
## Description
- Add BiometricError enum.
- Handler biometric errors using canEvaluatePolicy.

<!-- Commit message: This repository uses a commit message convention https://docs.google.com/document/d/19ed9FHIAlJwlGzf3xacgE15MVfTwx8n9G2QeYyCr-5E/edit?usp=drive_web&ouid=116864038767072405931 set the commit message to be used when merging this PR e.g. docs: add architecture diagrams [ACCSEC-99999] -->
## Commit message
-  

<!-- Screenshot: When possible add a screenshot or gif showing your changes if not you can remove this section -->
## Screenshot

<!-- Testing: Please check all that apply -->
## Testing
- [x] Added unit tests
- [x] Ran unit tests successfully
- [ ] Added documentation for public APIs and/or Wiki
