### PR TITLE
[23051][Fix] LAContext and AccessControl tests fixed.

### DIFF
--- a/TwilioVerifySDKTests/TwilioSecurity/Sources/Keychain/KeychainQueryTests.swift
+++ b/TwilioVerifySDKTests/TwilioSecurity/Sources/Keychain/KeychainQueryTests.swift
@@ -146,6 +146,28 @@ class KeychainQueryTests: XCTestCase {
       XCTAssertEqual(query[kSecAttrAccount.asString] as? String, testKey)
       XCTAssertEqual(query[kSecUseOperationPrompt.asString] as? String, authenticationPromptTestKey)
   }
+  
+  func testCreateQuery_withAccessControl_shouldHaveGivenAttributes() {
+    guard
+      let data = "data".data(using: .utf8),
+      let accessControl = try? StubLAContext.getAccessControl(keychain: keychain) else {
+        XCTFail("Unable to create Test mock data.")
+        return
+      }
+    
+    let query = KeychainQuery().save(
+      data: data,
+      withKey: Constants.alias,
+      accessControl: accessControl,
+      context: StubLAContext()
+    )
+    
+    XCTAssertNotNil(query[kSecClass.asString])
+    XCTAssertNotNil(query[kSecAttrAccount.asString])
+    XCTAssertNotNil(query[kSecValueData.asString])
+    XCTAssertNotNil(query[kSecAttrAccessControl.asString])
+    XCTAssertNotNil(query[kSecUseAuthenticationContext.asString])
+  }
 }
 
 private extension KeychainQueryTests {

--- a/TwilioVerifySDKTests/TwilioSecurity/Sources/Keychain/KeychainTests.swift
+++ b/TwilioVerifySDKTests/TwilioSecurity/Sources/Keychain/KeychainTests.swift
@@ -329,6 +329,27 @@ class KeychainTests: XCTestCase {
     XCTAssertNoThrow(query)
     XCTAssertEqual(status, errSecSuccess)
   }
+
+  func testCreateQuery_withAccessControl_shouldFail() {
+    guard
+      let data = "data".data(using: .utf8),
+      let accessControl = try? StubLAContext.getAccessControl(keychain: keychain) else {
+        XCTFail("Unable to create Test mock data.")
+        return
+      }
+    
+    let query = KeychainQuery().save(
+      data: data,
+      withKey: Constants.alias,
+      accessControl: accessControl,
+      context: StubLAContext()
+    )
+    
+    let status: OSStatus = keychain.addItem(withQuery: query)
+    
+    XCTAssertNoThrow(query)
+    XCTAssertEqual(status, errSecAuthFailed)
+  }
 }
 
 private extension KeychainTests {

--- a/TwilioVerifySDKTests/TwilioSecurity/Sources/Storage/Mocks/StubLAContext.swift
+++ b/TwilioVerifySDKTests/TwilioSecurity/Sources/Storage/Mocks/StubLAContext.swift
@@ -3,6 +3,24 @@ import Foundation
 @testable import TwilioVerifySDK
 
 class StubLAContext: LAContext {
-  override func evaluatePolicy(_ policy: LAPolicy, localizedReason: String, reply: @escaping (Bool, Error?) -> Void) {}
-  override func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool { return true }
+  override func evaluatePolicy(
+    _ policy: LAPolicy,
+    localizedReason: String,
+    reply: @escaping (Bool, Error?) -> Void
+  ) {}
+  
+  override func canEvaluatePolicy(
+    _ policy: LAPolicy,
+    error: NSErrorPointer
+  ) -> Bool { true }
+  
+  static func getAccessControl(
+    keychain: KeychainProtocol
+  ) throws -> SecAccessControl {
+    
+    return try keychain.accessControl(
+      withProtection: kSecAttrAccessibleAlways,
+      flags: .touchIDCurrentSet
+    )
+  }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Twilio Verify. Please consider this template for your PR -->
<!-- Title format: [Ticket Number/Issue Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (task, bug, housekeeping, etc) -->


<!-- Ticket: Please add the ticket number or the Github issue number according to your case -->
## Ticket
- [23051]

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->
## Description
- Tests created to validate Keychain with AccessControl and LAContext.
- Tests moved to specific class in order to run them on real devices only (integration suite).

<!-- Commit message: This repository uses a commit message convention https://docs.google.com/document/d/19ed9FHIAlJwlGzf3xacgE15MVfTwx8n9G2QeYyCr-5E/edit?usp=drive_web&ouid=116864038767072405931 set the commit message to be used when merging this PR e.g. docs: add architecture diagrams [99999] -->
## Commit message
- [23051][Fix] LAContext and AccessControl tests fixed.

<!-- Screenshot: When possible add a screenshot or gif showing your changes if not you can remove this section -->
## Screenshot

<!-- Testing: Please check all that apply -->
## Testing
- [ ] Added unit tests
- [ ] Ran unit tests successfully
- [ ] Added documentation for public APIs and/or Wiki
