### PR TITLE
[23526] Fix clear storage on reinstall

### DIFF
--- a/TwilioVerifySDK/TwilioSecurity/Sources/Keychain/KeychainQuery.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Keychain/KeychainQuery.swift
@@ -98,13 +98,11 @@ struct KeychainQuery: KeychainQueryProtocol {
   
   func delete(withKey key: String) -> Query {
     [kSecClass: kSecClassGenericPassword,
-     kSecAttrAccount: key,
-     kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
+     kSecAttrAccount: key] as Query
   }
   
   func deleteItems(withServiceName service: String) -> Query {
     [kSecClass: kSecClassGenericPassword,
-     kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
-     kSecAttrService: service,] as Query
+     kSecAttrService: service] as Query
   }
 }

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Keychain/KeychainQuery.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Keychain/KeychainQuery.swift
@@ -39,11 +39,11 @@ protocol KeychainQueryProtocol {
   func key(withTemplate template: SignerTemplate, class keyClass: KeyAttrClass) -> Query
   func saveKey(_ key: SecKey, withAlias alias: String) -> Query
   func deleteKey(withAlias alias: String) -> Query
-  func save(data: Data, withKey key: String) -> Query
+  func save(data: Data, withKey key: String, withServiceName service: String) -> Query
   func getData(withKey key: String) -> Query
-  func getAll() -> Query
+  func getAll(withServiceName service: String?) -> Query
   func delete(withKey key: String) -> Query
-  func deleteItems() -> Query
+  func deleteItems(withServiceName service: String) -> Query
 }
 
 struct KeychainQuery: KeychainQueryProtocol {
@@ -69,10 +69,11 @@ struct KeychainQuery: KeychainQueryProtocol {
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
   }
   
-  func save(data: Data, withKey key: String) -> Query {
+  func save(data: Data, withKey key: String, withServiceName service: String) -> Query {
     [kSecClass: kSecClassGenericPassword,
      kSecAttrAccount: key,
      kSecValueData: data,
+     kSecAttrService: service,
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
   }
   
@@ -83,12 +84,16 @@ struct KeychainQuery: KeychainQueryProtocol {
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
   }
   
-  func getAll() -> Query {
-    [kSecClass: kSecClassGenericPassword,
+  func getAll(withServiceName service: String?) -> Query {
+    var query = [kSecClass: kSecClassGenericPassword,
      kSecReturnAttributes: true,
      kSecReturnData: true,
      kSecMatchLimit: kSecMatchLimitAll,
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
+    if let service = service {
+      query[kSecAttrService as String] = service
+    }
+    return query
   }
   
   func delete(withKey key: String) -> Query {
@@ -97,8 +102,9 @@ struct KeychainQuery: KeychainQueryProtocol {
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
   }
   
-  func deleteItems() -> Query {
+  func deleteItems(withServiceName service: String) -> Query {
     [kSecClass: kSecClassGenericPassword,
-    kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
+     kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+     kSecAttrService: service,] as Query
   }
 }

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Keychain/KeychainQuery.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Keychain/KeychainQuery.swift
@@ -39,11 +39,11 @@ protocol KeychainQueryProtocol {
   func key(withTemplate template: SignerTemplate, class keyClass: KeyAttrClass) -> Query
   func saveKey(_ key: SecKey, withAlias alias: String) -> Query
   func deleteKey(withAlias alias: String) -> Query
-  func save(data: Data, withKey key: String, withServiceName service: String) -> Query
+  func save(data: Data, withKey key: String, withServiceName service: String?) -> Query
   func getData(withKey key: String) -> Query
   func getAll(withServiceName service: String?) -> Query
   func delete(withKey key: String) -> Query
-  func deleteItems(withServiceName service: String) -> Query
+  func deleteItems(withServiceName service: String?) -> Query
 }
 
 struct KeychainQuery: KeychainQueryProtocol {
@@ -69,12 +69,15 @@ struct KeychainQuery: KeychainQueryProtocol {
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
   }
   
-  func save(data: Data, withKey key: String, withServiceName service: String) -> Query {
-    [kSecClass: kSecClassGenericPassword,
+  func save(data: Data, withKey key: String, withServiceName service: String?) -> Query {
+    var query = [kSecClass: kSecClassGenericPassword,
      kSecAttrAccount: key,
      kSecValueData: data,
-     kSecAttrService: service,
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
+    if let service = service {
+      query[kSecAttrService as String] = service
+    }
+    return query
   }
   
   func getData(withKey key: String) -> Query {
@@ -101,8 +104,11 @@ struct KeychainQuery: KeychainQueryProtocol {
      kSecAttrAccount: key] as Query
   }
   
-  func deleteItems(withServiceName service: String) -> Query {
-    [kSecClass: kSecClassGenericPassword,
-     kSecAttrService: service] as Query
+  func deleteItems(withServiceName service: String?) -> Query {
+    var query = [kSecClass: kSecClassGenericPassword] as Query
+    if let service = service {
+      query[kSecAttrService as String] = service
+    }
+    return query
   }
 }

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Keychain/KeychainQuery.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Keychain/KeychainQuery.swift
@@ -39,7 +39,7 @@ protocol KeychainQueryProtocol {
   func key(withTemplate template: SignerTemplate, class keyClass: KeyAttrClass) -> Query
   func saveKey(_ key: SecKey, withAlias alias: String) -> Query
   func deleteKey(withAlias alias: String) -> Query
-  func save(data: Data, withKey key: String, withServiceName service: String?) -> Query
+  func save(data: Data, withKey key: String, withServiceName service: String) -> Query
   func getData(withKey key: String) -> Query
   func getAll(withServiceName service: String?) -> Query
   func delete(withKey key: String) -> Query
@@ -69,15 +69,12 @@ struct KeychainQuery: KeychainQueryProtocol {
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
   }
   
-  func save(data: Data, withKey key: String, withServiceName service: String?) -> Query {
-    var query = [kSecClass: kSecClassGenericPassword,
+  func save(data: Data, withKey key: String, withServiceName service: String) -> Query {
+    [kSecClass: kSecClassGenericPassword,
      kSecAttrAccount: key,
      kSecValueData: data,
+     kSecAttrService: service,
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
-    if let service = service {
-      query[kSecAttrService as String] = service
-    }
-    return query
   }
   
   func getData(withKey key: String) -> Query {

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Keychain/KeychainQuery.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Keychain/KeychainQuery.swift
@@ -39,7 +39,7 @@ protocol KeychainQueryProtocol {
   func key(withTemplate template: SignerTemplate, class keyClass: KeyAttrClass) -> Query
   func saveKey(_ key: SecKey, withAlias alias: String) -> Query
   func deleteKey(withAlias alias: String) -> Query
-  func save(data: Data, withKey key: String, withServiceName service: String) -> Query
+  func save(data: Data, withKey key: String, withServiceName service: String?) -> Query
   func getData(withKey key: String) -> Query
   func getAll(withServiceName service: String?) -> Query
   func delete(withKey key: String) -> Query
@@ -69,12 +69,15 @@ struct KeychainQuery: KeychainQueryProtocol {
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
   }
   
-  func save(data: Data, withKey key: String, withServiceName service: String) -> Query {
-    [kSecClass: kSecClassGenericPassword,
+  func save(data: Data, withKey key: String, withServiceName service: String?) -> Query {
+    var query = [kSecClass: kSecClassGenericPassword,
      kSecAttrAccount: key,
      kSecValueData: data,
-     kSecAttrService: service,
      kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly] as Query
+    if let service = service {
+      query[kSecAttrService as String] = service
+    }
+    return query
   }
   
   func getData(withKey key: String) -> Query {

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Storage/SecureStorage.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Storage/SecureStorage.swift
@@ -21,11 +21,11 @@ import Foundation
 
 ///:nodoc:
 public protocol SecureStorageProvider {
-  func save(_ data: Data, withKey key: String, withServiceName service: String) throws
+  func save(_ data: Data, withKey key: String, withServiceName service: String?) throws
   func get(_ key: String) throws -> Data
   func removeValue(for key: String) throws
   func getAll(withServiceName service: String?) throws -> [Data]
-  func clear(withServiceName service: String) throws
+  func clear(withServiceName service: String?) throws
 }
 
 ///:nodoc:
@@ -46,7 +46,7 @@ public class SecureStorage {
 }
 
 extension SecureStorage: SecureStorageProvider {
-  public func save(_ data: Data, withKey key: String, withServiceName service: String) throws {
+  public func save(_ data: Data, withKey key: String, withServiceName service: String?) throws {
     Logger.shared.log(withLevel: .info, message: "Saving \(key)")
     let deleteQuery = keychainQuery.delete(withKey: key)
     keychain.deleteItem(withQuery: deleteQuery)
@@ -108,7 +108,7 @@ extension SecureStorage: SecureStorageProvider {
     }
   }
   
-  public func clear(withServiceName service: String) throws {
+  public func clear(withServiceName service: String?) throws {
     Logger.shared.log(withLevel: .info, message: "Clearing storage")
     if try !getAll(withServiceName: service).isEmpty {
       let query = keychainQuery.deleteItems(withServiceName: service)

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Storage/SecureStorage.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Storage/SecureStorage.swift
@@ -48,6 +48,8 @@ public class SecureStorage {
 extension SecureStorage: SecureStorageProvider {
   public func save(_ data: Data, withKey key: String, withServiceName service: String) throws {
     Logger.shared.log(withLevel: .info, message: "Saving \(key)")
+    let queryWithoutService = keychainQuery.save(data: data, withKey: key, withServiceName: nil)
+    keychain.deleteItem(withQuery: queryWithoutService)
     let query = keychainQuery.save(data: data, withKey: key, withServiceName: service)
     let status = keychain.addItem(withQuery: query)
     guard status == errSecSuccess else {

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Storage/SecureStorage.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Storage/SecureStorage.swift
@@ -48,8 +48,8 @@ public class SecureStorage {
 extension SecureStorage: SecureStorageProvider {
   public func save(_ data: Data, withKey key: String, withServiceName service: String) throws {
     Logger.shared.log(withLevel: .info, message: "Saving \(key)")
-    let queryWithoutService = keychainQuery.save(data: data, withKey: key, withServiceName: nil)
-    keychain.deleteItem(withQuery: queryWithoutService)
+    let deleteQuery = keychainQuery.delete(withKey: key)
+    keychain.deleteItem(withQuery: deleteQuery)
     let query = keychainQuery.save(data: data, withKey: key, withServiceName: service)
     let status = keychain.addItem(withQuery: query)
     guard status == errSecSuccess else {

--- a/TwilioVerifySDK/TwilioSecurity/Sources/Storage/SecureStorage.swift
+++ b/TwilioVerifySDK/TwilioSecurity/Sources/Storage/SecureStorage.swift
@@ -21,11 +21,11 @@ import Foundation
 
 ///:nodoc:
 public protocol SecureStorageProvider {
-  func save(_ data: Data, withKey key: String) throws
+  func save(_ data: Data, withKey key: String, withServiceName service: String) throws
   func get(_ key: String) throws -> Data
   func removeValue(for key: String) throws
-  func getAll() throws -> [Data]
-  func clear() throws
+  func getAll(withServiceName service: String?) throws -> [Data]
+  func clear(withServiceName service: String) throws
 }
 
 ///:nodoc:
@@ -46,9 +46,9 @@ public class SecureStorage {
 }
 
 extension SecureStorage: SecureStorageProvider {
-  public func save(_ data: Data, withKey key: String) throws {
+  public func save(_ data: Data, withKey key: String, withServiceName service: String) throws {
     Logger.shared.log(withLevel: .info, message: "Saving \(key)")
-    let query = keychainQuery.save(data: data, withKey: key)
+    let query = keychainQuery.save(data: data, withKey: key, withServiceName: service)
     let status = keychain.addItem(withQuery: query)
     guard status == errSecSuccess else {
       let error = NSError(domain: NSOSStatusErrorDomain, code: Int(status), userInfo: nil)
@@ -73,9 +73,9 @@ extension SecureStorage: SecureStorageProvider {
     }
   }
   
-  public func getAll() throws -> [Data] {
+  public func getAll(withServiceName service: String?) throws -> [Data] {
     Logger.shared.log(withLevel: .info, message: "Getting all values")
-    let query = keychainQuery.getAll()
+    let query = keychainQuery.getAll(withServiceName: service)
     do {
       let result = try keychain.copyItemMatching(query: query)
       guard let resultArray = result as? [Any] else {
@@ -106,10 +106,10 @@ extension SecureStorage: SecureStorageProvider {
     }
   }
   
-  public func clear() throws {
+  public func clear(withServiceName service: String) throws {
     Logger.shared.log(withLevel: .info, message: "Clearing storage")
-    if try !getAll().isEmpty {
-      let query = keychainQuery.deleteItems()
+    if try !getAll(withServiceName: service).isEmpty {
+      let query = keychainQuery.deleteItems(withServiceName: service)
       let status = keychain.deleteItem(withQuery: query)
       guard status == errSecSuccess else {
         let error = NSError(domain: NSOSStatusErrorDomain, code: Int(status), userInfo: nil)

--- a/TwilioVerifySDK/TwilioVerify/Sources/Data/Storage.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/Data/Storage.swift
@@ -110,7 +110,7 @@ private extension Storage {
         break
       }
     }
-    updateVersion(version: Constants.version)
+    updateVersion(version: version)
     updateClearStorageOnReinstall(value: clearStorageOnReinstall)
   }
   
@@ -145,7 +145,7 @@ private extension Storage {
     guard let clearStorageOnReinstallValue = value.description.data(using: .utf8) else {
       return
     }
-    try? secureStorage.save(clearStorageOnReinstallValue, withKey: Constants.clearStorageOnReinstallKey, withServiceName: nil)
+    try? secureStorage.save(clearStorageOnReinstallValue, withKey: Constants.clearStorageOnReinstallKey, withServiceName: Constants.service)
   }
 }
 

--- a/TwilioVerifySDK/TwilioVerify/Sources/Data/Storage.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/Data/Storage.swift
@@ -92,6 +92,10 @@ private extension Storage {
     guard currentVersion < version else {
       return
     }
+    if let hasItems = try? !getAll().isEmpty, currentVersion == Constants.noVersion && hasItems && !clearStorageOnReinstall {
+      currentVersion = 1
+      updateVersion(version: currentVersion)
+    }
     if currentVersion == Constants.noVersion && clearStorageOnReinstall {
       try? clearItemsWithoutService()
       try clear()
@@ -108,6 +112,7 @@ private extension Storage {
         break
       }
     }
+    updateVersion(version: Constants.version)
   }
   
   func applyMigration(_ migration: Migration) throws {
@@ -123,7 +128,7 @@ private extension Storage {
   }
   
   func clearItemsWithoutService() throws {
-    let migration = AddServiceToFactors(secureStorage: secureStorage)
+    let migration = AddKeychainServiceToFactors(secureStorage: secureStorage)
     let migrationResult = migration.migrate(data: try secureStorage.getAll(withServiceName: Constants.service))
     for result in migrationResult {
       try removeValue(for: result.key)

--- a/TwilioVerifySDK/TwilioVerify/Sources/Data/Storage.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/Data/Storage.swift
@@ -93,7 +93,7 @@ private extension Storage {
       return
     }
     if currentVersion == Constants.noVersion && clearStorageOnReinstall {
-      try? addServiceToKeychainItems()
+      try? clearItemsWithoutService()
       try clear()
       updateVersion(version: Constants.version)
       return
@@ -122,11 +122,11 @@ private extension Storage {
     userDefaults.set(version, forKey: Constants.currentVersionKey)
   }
   
-  func addServiceToKeychainItems() throws {
-    let migration = AddServiceToKeychainItems(secureStorage: secureStorage)
+  func clearItemsWithoutService() throws {
+    let migration = AddServiceToFactors(secureStorage: secureStorage)
     let migrationResult = migration.migrate(data: try secureStorage.getAll(withServiceName: Constants.service))
     for result in migrationResult {
-      try save(result.value, withKey: result.key)
+      try removeValue(for: result.key)
     }
   }
 }

--- a/TwilioVerifySDK/TwilioVerify/Sources/Domain/Factor/FactorMigrations.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/Domain/Factor/FactorMigrations.swift
@@ -25,7 +25,7 @@ struct FactorMigrations {
   }
 }
 
-class AddServiceToFactors: Migration {
+class AddKeychainServiceToFactors: Migration {
   
   private let secureStorage: SecureStorageProvider
   private let factorMapper: FactorMapper

--- a/TwilioVerifySDK/TwilioVerify/Sources/Domain/Factor/FactorMigrations.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/Domain/Factor/FactorMigrations.swift
@@ -25,7 +25,7 @@ struct FactorMigrations {
   }
 }
 
-class AddServiceToKeychainItems: Migration {
+class AddServiceToFactors: Migration {
   
   private let secureStorage: SecureStorageProvider
   private let factorMapper: FactorMapper

--- a/TwilioVerifySDK/TwilioVerify/Sources/Domain/Factor/FactorRepository.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/Domain/Factor/FactorRepository.swift
@@ -126,6 +126,13 @@ extension FactorRepository: FactorProvider {
   }
   
   func clearLocalStorage() throws {
-    try storage.clear()
+    do {
+      try getAll().forEach { factor in
+        try delete(factor)
+      }
+    } catch {
+      Logger.shared.log(withLevel: .error, message: error.localizedDescription)
+      try storage.clear()
+    }
   }
 }

--- a/TwilioVerifySDKTests/TwilioSecurity/Sources/Keychain/KeychainQueryTests.swift
+++ b/TwilioVerifySDKTests/TwilioSecurity/Sources/Keychain/KeychainQueryTests.swift
@@ -76,7 +76,7 @@ class KeychainQueryTests: XCTestCase {
   
   func testSaveData_withKey_shouldReturnValidQuery() {
     let expectedData = "data".data(using: .utf8)!
-    let query = keychainQuery.save(data: expectedData, withKey: Constants.alias)
+    let query = keychainQuery.save(data: expectedData, withKey: Constants.alias, withServiceName: Constants.service)
     let keyClass = query[kSecClass as String] as! CFString
     let label = query[kSecAttrAccount as String] as! String
     let access = query[kSecAttrAccessible as String] as! CFString
@@ -100,7 +100,7 @@ class KeychainQueryTests: XCTestCase {
   }
   
   func testGetAllData_shouldReturnValidQuery() {
-    let query = keychainQuery.getAll()
+    let query = keychainQuery.getAll(withServiceName: nil)
     let keyClass = query[kSecClass as String] as! CFString
     let returnAttributes = query[kSecReturnAttributes as String] as! CFBoolean
     let returnData = query[kSecReturnData as String] as! CFBoolean
@@ -126,7 +126,7 @@ class KeychainQueryTests: XCTestCase {
   }
   
   func testDeleteItems_shouldReturnValidQuery() {
-    let query = keychainQuery.deleteItems()
+    let query = keychainQuery.deleteItems(withServiceName: Constants.service)
     let keyClass = query[kSecClass as String] as! CFString
     let access = query[kSecAttrAccessible as String] as! CFString
     
@@ -138,5 +138,6 @@ class KeychainQueryTests: XCTestCase {
 private extension KeychainQueryTests {
   struct Constants {
     static let alias = "signerAlias"
+    static let service = "service"
   }
 }

--- a/TwilioVerifySDKTests/TwilioSecurity/Sources/Keychain/KeychainQueryTests.swift
+++ b/TwilioVerifySDKTests/TwilioSecurity/Sources/Keychain/KeychainQueryTests.swift
@@ -118,20 +118,18 @@ class KeychainQueryTests: XCTestCase {
     let query = keychainQuery.delete(withKey: Constants.alias)
     let keyClass = query[kSecClass as String] as! CFString
     let label = query[kSecAttrAccount as String] as! String
-    let access = query[kSecAttrAccessible as String] as! CFString
     
     XCTAssertEqual(keyClass, kSecClassGenericPassword)
     XCTAssertEqual(label, Constants.alias)
-    XCTAssertEqual(access, kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
   }
   
   func testDeleteItems_shouldReturnValidQuery() {
     let query = keychainQuery.deleteItems(withServiceName: Constants.service)
     let keyClass = query[kSecClass as String] as! CFString
-    let access = query[kSecAttrAccessible as String] as! CFString
+    let service = query[kSecAttrService as String] as! String
     
     XCTAssertEqual(keyClass, kSecClassGenericPassword)
-    XCTAssertEqual(access, kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
+    XCTAssertEqual(service, Constants.service)
   }
 }
 

--- a/TwilioVerifySDKTests/TwilioSecurity/Sources/Keychain/KeychainTests.swift
+++ b/TwilioVerifySDKTests/TwilioSecurity/Sources/Keychain/KeychainTests.swift
@@ -250,7 +250,7 @@ class KeychainTests: XCTestCase {
     let expectedErrorDomain = "NSOSStatusErrorDomain"
     let expectedLocalizedDescription = "The operation couldn’t be completed. (OSStatus error -25300.)"
     let data = "data".data(using: .utf8)!
-    let query = KeychainQuery().save(data: data, withKey: Constants.alias)
+    let query = KeychainQuery().save(data: data, withKey: Constants.alias, withServiceName: Constants.service)
     let status = keychain.addItem(withQuery: query)
     XCTAssertEqual(status, errSecSuccess, "Adding an item should succeed")
     XCTAssertThrowsError(try keychain.copyItemMatching(query: Constants.keyQuery), "Copy Item matching should throw") { error in
@@ -317,6 +317,7 @@ class KeychainTests: XCTestCase {
 private extension KeychainTests {
   struct Constants {
     static let alias = "alias"
+    static let service = "service"
     static let algorithm: SecKeyAlgorithm = .ecdsaSignatureMessageX962SHA256
     static let keyQuery = [kSecClass: kSecClassKey,
                            kSecAttrKeyClass: kSecAttrKeyClassPublic,

--- a/TwilioVerifySDKTests/TwilioSecurity/Sources/Storage/SecureStorageTests.swift
+++ b/TwilioVerifySDKTests/TwilioSecurity/Sources/Storage/SecureStorageTests.swift
@@ -41,6 +41,7 @@ class SecureStorageTests: XCTestCase {
     let key = "key"
     let expectedErrorCode = errSecDuplicateItem
     let expectedLocalizedDescription = "The operation couldn’t be completed. (OSStatus error -25299.)"
+    keychain.deleteItemStatus = errSecSuccess
     keychain.addItemStatus = [expectedErrorCode]
     XCTAssertThrowsError(try storage.save(data, withKey: key, withServiceName: "service"), "Save should throw") { error in
       let thrownError = error as NSError
@@ -66,6 +67,7 @@ class SecureStorageTests: XCTestCase {
     let data = "data".data(using: .utf8)!
     let key = "key"
     keychain.addItemStatus = [errSecSuccess]
+    keychain.deleteItemStatus = errSecSuccess
     XCTAssertNoThrow(try storage.save(data, withKey: key, withServiceName: "service"), "Save should not throw")
   }
   

--- a/TwilioVerifySDKTests/TwilioSecurity/Sources/Storage/SecureStorageTests.swift
+++ b/TwilioVerifySDKTests/TwilioSecurity/Sources/Storage/SecureStorageTests.swift
@@ -42,7 +42,7 @@ class SecureStorageTests: XCTestCase {
     let expectedErrorCode = errSecDuplicateItem
     let expectedLocalizedDescription = "The operation couldn’t be completed. (OSStatus error -25299.)"
     keychain.addItemStatus = [expectedErrorCode]
-    XCTAssertThrowsError(try storage.save(data, withKey: key), "Save should throw") { error in
+    XCTAssertThrowsError(try storage.save(data, withKey: key, withServiceName: "service"), "Save should throw") { error in
       let thrownError = error as NSError
       XCTAssertEqual(
         thrownError.code,
@@ -66,7 +66,7 @@ class SecureStorageTests: XCTestCase {
     let data = "data".data(using: .utf8)!
     let key = "key"
     keychain.addItemStatus = [errSecSuccess]
-    XCTAssertNoThrow(try storage.save(data, withKey: key), "Save should not throw")
+    XCTAssertNoThrow(try storage.save(data, withKey: key, withServiceName: "service"), "Save should not throw")
   }
   
   func testGet_valueExistsForKey_shouldReturnValue() {
@@ -97,7 +97,7 @@ class SecureStorageTests: XCTestCase {
     let valueData2 = [kSecValueData as String: expectedData2]
     var data: [Data?]!
     keychain.keys = [[valueData1, valueData2] as AnyObject]
-    XCTAssertNoThrow(data = try storage.getAll(), "Get all should not throw")
+    XCTAssertNoThrow(data = try storage.getAll(withServiceName: nil), "Get all should not throw")
     XCTAssertEqual(data.first, expectedData1, "Data should be \(expectedData1) but was \(data!.first!!)")
     XCTAssertEqual(data.last, expectedData2, "Data should be \(expectedData2) but was \(data!.last!!)")
   }
@@ -105,7 +105,7 @@ class SecureStorageTests: XCTestCase {
   func testGetAllData_withoutDataSaved_shouldReturnEmptyArray() {
     var data: [Data?]!
     keychain.keys = ["data".data(using: .utf8)! as AnyObject]
-    XCTAssertNoThrow(data = try storage.getAll(), "Get all should not throw")
+    XCTAssertNoThrow(data = try storage.getAll(withServiceName: nil), "Get all should not throw")
     XCTAssertTrue(data.isEmpty)
   }
   
@@ -126,13 +126,13 @@ class SecureStorageTests: XCTestCase {
     let valueData2 = [kSecValueData as String: expectedData2]
     keychain.keys = [[valueData2] as AnyObject]
     keychain.deleteItemStatus = errSecSuccess
-    XCTAssertNoThrow(try storage.clear(), "Clear should not throw")
+    XCTAssertNoThrow(try storage.clear(withServiceName: "service"), "Clear should not throw")
     XCTAssertTrue(keychain.callOrder.contains(.deleteItem), "Delete should be called")
   }
   
   func testClear_noItems_shouldNotClearKeychain() {
     keychain.error = NSError(domain: "No items", code: Int(errSecItemNotFound), userInfo: nil)
-    XCTAssertNoThrow(try storage.clear(), "Clear should not throw")
+    XCTAssertNoThrow(try storage.clear(withServiceName: "service"), "Clear should not throw")
     XCTAssertFalse(keychain.callOrder.contains(.deleteItem), "Delete should not be called")
   }
   
@@ -142,7 +142,7 @@ class SecureStorageTests: XCTestCase {
     let valueData2 = [kSecValueData as String: expectedData2]
     keychain.keys = [[valueData2] as AnyObject]
     keychain.deleteItemStatus = errSecItemNotFound
-    XCTAssertThrowsError(try storage.clear(), "Clear should throw") { error in
+    XCTAssertThrowsError(try storage.clear(withServiceName: "service"), "Clear should throw") { error in
       let thrownError = error as NSError
       XCTAssertEqual(
         thrownError.code,

--- a/TwilioVerifySDKTests/TwilioVerify/Sources/Data/Mocks/SecureStorageMock.swift
+++ b/TwilioVerifySDKTests/TwilioVerify/Sources/Data/Mocks/SecureStorageMock.swift
@@ -32,7 +32,7 @@ class SecureStorageMock {
 }
 
 extension SecureStorageMock: SecureStorageProvider {
-  func save(_ data: Data, withKey key: String) throws {
+  func save(_ data: Data, withKey key: String, withServiceName service: String) throws {
     callsToSave += 1
     if let error = error {
       throw error
@@ -47,7 +47,7 @@ extension SecureStorageMock: SecureStorageProvider {
     return operationResult
   }
   
-  func getAll() throws -> [Data] {
+  func getAll(withServiceName service: String?) throws -> [Data] {
     callsToGetAll += 1
     if let error = error {
       throw error
@@ -62,7 +62,7 @@ extension SecureStorageMock: SecureStorageProvider {
     }
   }
   
-  func clear() throws {
+  func clear(withServiceName service: String) throws {
     callsToClear += 1
     if let error = error {
       throw error

--- a/TwilioVerifySDKTests/TwilioVerify/Sources/Data/Mocks/SecureStorageMock.swift
+++ b/TwilioVerifySDKTests/TwilioVerify/Sources/Data/Mocks/SecureStorageMock.swift
@@ -22,8 +22,7 @@ import Foundation
 
 class SecureStorageMock {
   var error: Error?
-  var operationResult: Data!
-  var objectsData: [Data]!
+  var objectsData: [String: Data] = [:]
   private(set) var callsToSave = 0
   private(set) var callsToGet = 0
   private(set) var callsToRemoveValue = 0
@@ -32,11 +31,12 @@ class SecureStorageMock {
 }
 
 extension SecureStorageMock: SecureStorageProvider {
-  func save(_ data: Data, withKey key: String, withServiceName service: String) throws {
+  func save(_ data: Data, withKey key: String, withServiceName service: String?) throws {
     callsToSave += 1
     if let error = error {
       throw error
     }
+    objectsData[key] = data
   }
   
   func get(_ key: String) throws -> Data {
@@ -44,7 +44,10 @@ extension SecureStorageMock: SecureStorageProvider {
     if let error = error {
       throw error
     }
-    return operationResult
+    guard let value = objectsData[key] else {
+      throw NSError(domain: NSOSStatusErrorDomain, code: Int(1), userInfo: nil)
+    }
+    return value
   }
   
   func getAll(withServiceName service: String?) throws -> [Data] {
@@ -52,7 +55,7 @@ extension SecureStorageMock: SecureStorageProvider {
     if let error = error {
       throw error
     }
-    return objectsData
+    return Array(objectsData.values)
   }
   
   func removeValue(for key: String) throws {
@@ -60,12 +63,14 @@ extension SecureStorageMock: SecureStorageProvider {
     if let error = error {
       throw error
     }
+    objectsData.removeValue(forKey: key)
   }
   
-  func clear(withServiceName service: String) throws {
+  func clear(withServiceName service: String?) throws {
     callsToClear += 1
     if let error = error {
       throw error
     }
+    objectsData.removeAll()
   }
 }

--- a/TwilioVerifySDKTests/TwilioVerify/Sources/Data/StorageTests.swift
+++ b/TwilioVerifySDKTests/TwilioVerify/Sources/Data/StorageTests.swift
@@ -100,6 +100,8 @@ class StorageTests: XCTestCase {
   
   func testInit_withClearStorageOnReinstall_shouldCallSecureStorageClear() {
     let expectedCallsToMethod = 1
+    let expectedData = [Constants.data]
+    secureStorage.objectsData = expectedData
     let userDefaults: UserDefaults = .standard
     userDefaults.removeObject(forKey: Storage.Constants.currentVersionKey)
     storage = try! Storage(secureStorage: secureStorage, userDefaults: userDefaults, migrations: [], clearStorageOnReinstall: true)
@@ -116,7 +118,7 @@ class StorageTests: XCTestCase {
     )
   }
   
-  func testInit_withNoClearStorageOnReinstall_shouldCallSecureStorageClear() {
+  func testInit_withNoClearStorageOnReinstall_shouldNotCallSecureStorageClear() {
     let expectedCallsToMethod = 0
     let userDefaults: UserDefaults = .standard
     userDefaults.removeObject(forKey: Storage.Constants.currentVersionKey)
@@ -130,6 +132,8 @@ class StorageTests: XCTestCase {
   
   func testInit_withClearStorageOnReinstallAndMigrations_shouldNotMigrate() {
     let expectedCallsToMethod = 0
+    let expectedData = [Constants.data]
+    secureStorage.objectsData = expectedData
     let userDefaults: UserDefaults = .standard
     userDefaults.removeObject(forKey: Storage.Constants.currentVersionKey)
     let migrationV0ToV1 = MigrationMock(startVersion: 0, endVersion: 1)

--- a/TwilioVerifySDKTests/TwilioVerify/Sources/Data/StorageTests.swift
+++ b/TwilioVerifySDKTests/TwilioVerify/Sources/Data/StorageTests.swift
@@ -121,6 +121,8 @@ class StorageTests: XCTestCase {
   func testInit_withNoClearStorageOnReinstall_shouldNotCallSecureStorageClear() {
     let expectedCallsToMethod = 0
     let userDefaults: UserDefaults = .standard
+    let expectedData = [Constants.data]
+    secureStorage.objectsData = expectedData
     userDefaults.removeObject(forKey: Storage.Constants.currentVersionKey)
     storage = try! Storage(secureStorage: secureStorage, userDefaults: userDefaults, migrations: [], clearStorageOnReinstall: false)
     XCTAssertEqual(
@@ -241,7 +243,7 @@ private extension StorageTests {
   func initStorage(withMigrations migrations: [Migration], withStartVersion startVersion: Int, withEndVersion endVersion: Int) {
     let userDefaults: UserDefaults = .standard
     userDefaults.set(startVersion, forKey: Storage.Constants.currentVersionKey)
-    storage = try! Storage(secureStorage: secureStorage, userDefaults: userDefaults, migrations: migrations, clearStorageOnReinstall: false)
+    storage = try! Storage(secureStorage: secureStorage, userDefaults: userDefaults, migrations: migrations, clearStorageOnReinstall: true)
     let currentVersion = userDefaults.integer(forKey: Storage.Constants.currentVersionKey)
     XCTAssertEqual(
       currentVersion,

--- a/TwilioVerifySDKTests/TwilioVerify/Sources/Domain/Factor/FactorRepositoryTests.swift
+++ b/TwilioVerifySDKTests/TwilioVerify/Sources/Domain/Factor/FactorRepositoryTests.swift
@@ -506,6 +506,13 @@ class FactorRepositoryTests: XCTestCase {
   }
   
   func testClearLocalStorage_withError_shouldThrowError() {
+    let factor1ExpectedSid = "sid123"
+    let factor1 = Constants.generateFactor(withSid: factor1ExpectedSid)
+    let factorData1 = try! JSONEncoder().encode(factor1)
+    factorMapper.expectedData = factorData1
+    storage.factorsData = [factorData1]
+    storage.errorRemoving = TestError.operationFailed
+    storage.expectedSid = factor1ExpectedSid
     storage.errorClearing = TestError.operationFailed
     XCTAssertThrowsError(try factorRepository.clearLocalStorage(), "Clear should throw") { error in
       XCTAssertEqual((error as! TestError), TestError.operationFailed)
@@ -513,6 +520,11 @@ class FactorRepositoryTests: XCTestCase {
   }
   
   func testClearLocalStorage_withoutErrors_shouldClearSecureStorage() {
+    let factor1ExpectedSid = "sid123"
+    let factor1 = Constants.generateFactor(withSid: factor1ExpectedSid)
+    let factorData1 = try! JSONEncoder().encode(factor1)
+    factorMapper.expectedData = factorData1
+    storage.factorsData = [factorData1]
     XCTAssertNoThrow(try factorRepository.clearLocalStorage(), "Clear should not throw")
   }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,7 +5,7 @@ single_ftl_device = [{ios_model_id: 'iphone11pro', ios_version_id: '14.7'}]
 all_ftl_devices = [
   {ios_model_id: 'iphone11', ios_version_id: '13.6'},
   {ios_model_id: 'iphone11pro', ios_version_id: '13.3'},
-  {ios_model_id: 'iphonexr', ios_version_id: '12.4'},
+  {ios_model_id: 'iphone8', ios_version_id: '12.4'},
   {ios_model_id: 'iphone8', ios_version_id: '11.4'}
 ]
 


### PR DESCRIPTION
<!-- Thanks for contributing to Twilio Verify. Please consider this template for your PR -->
<!-- Title format: [Ticket Number/Issue Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (task, bug, housekeeping, etc) -->


<!-- Ticket: Please add the ticket number or the Github issue number according to your case -->
## Ticket
- [23526]

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->
## Description
- Prevent deleting other keychain items on reinstall

<!-- Commit message: This repository uses a commit message convention https://docs.google.com/document/d/19ed9FHIAlJwlGzf3xacgE15MVfTwx8n9G2QeYyCr-5E/edit?usp=drive_web&ouid=116864038767072405931 set the commit message to be used when merging this PR e.g. docs: add architecture diagrams [99999] -->
## Commit message
-  fix: Clearing storage after reinstall will remove only factors. Previous implementation was removing all the keychain items on reinstall
BREAKING CHANGE: A reinstall using this version will not clear the SDK storage if the user did not update to this SDK version before

<!-- Screenshot: When possible add a screenshot or gif showing your changes if not you can remove this section -->
## Screenshot

<!-- Testing: Please check all that apply -->
## Testing
- [x] Added unit tests
- [x] Ran unit tests successfully
- [ ] Added documentation for public APIs and/or Wiki
