### PR TITLE
[23686] Cache implemented with initial service extension

### DIFF
--- a/TwilioVerify.xcworkspace/contents.xcworkspacedata
+++ b/TwilioVerify.xcworkspace/contents.xcworkspacedata
@@ -8,6 +8,9 @@
       location = "group:TwilioVerifyDemo/TwilioVerifyDemo.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:TwilioVerifyDemoCache">
+   </FileRef>
+   <FileRef
       location = "group:TwilioVerifySDK.xcodeproj">
    </FileRef>
 </Workspace>

--- a/TwilioVerifyDemo/NotificationExtension/Info.plist
+++ b/TwilioVerifyDemo/NotificationExtension/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/TwilioVerifyDemo/NotificationExtension/NotificationExtension.entitlements
+++ b/TwilioVerifyDemo/NotificationExtension/NotificationExtension.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.twilio.TwilioVerifyDemo</string>
+	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.twilio.TwilioVerifyDemo</string>
+	</array>
+</dict>
+</plist>

--- a/TwilioVerifyDemo/NotificationExtension/NotificationService.swift
+++ b/TwilioVerifyDemo/NotificationExtension/NotificationService.swift
@@ -1,0 +1,61 @@
+//
+//  NotificationService.swift
+//  TwilioVerifyDemo
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UserNotifications
+import TwilioVerifySDK
+import TwilioVerifyDemoCache
+
+class NotificationService: UNNotificationServiceExtension {
+  
+  var contentHandler: ((UNNotificationContent) -> Void)?
+  var bestAttemptContent: UNMutableNotificationContent?
+  
+  override func didReceive(
+    _ request: UNNotificationRequest,
+    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+  ) {
+    self.contentHandler = contentHandler
+    bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
+    
+    if let bestAttemptContent = bestAttemptContent {
+      // Modify the notification content here...
+      bestAttemptContent.title = "\(bestAttemptContent.title) [modified]"
+      
+      // Retrieve challenge from TwilioSDK and save it on TwilioVerifyDemoCache
+      // Use extension method `toAppChallenge()` to convert the one retrieved from the SDK
+      let testChallenge = AppChallenge(
+        sid: "sid3",
+        challengeDetails: AppChallengeDetails(message: .init(), fields: []),
+        hiddenDetails: nil,
+        factorSid: "factorSid",
+        status: .pending,
+        updatedAt: Date(),
+        expirationDate: Date()
+      )
+      
+      ChallengesCache.save(challenge: testChallenge)
+      
+      contentHandler(bestAttemptContent)
+    }
+  }
+  
+  override func serviceExtensionTimeWillExpire() {
+    if let contentHandler = contentHandler, let bestAttemptContent =  bestAttemptContent {
+      contentHandler(bestAttemptContent)
+    }
+  }
+}

--- a/TwilioVerifyDemo/TwilioVerifyDemo.xcodeproj/project.pbxproj
+++ b/TwilioVerifyDemo/TwilioVerifyDemo.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		860BB68C262A018A00E021C9 /* TwilioVerifySDK in Frameworks */ = {isa = PBXBuildFile; productRef = 860BB68B262A018A00E021C9 /* TwilioVerifySDK */; };
+		97AC071D2797704300752055 /* TwilioVerifyDemoCache in Frameworks */ = {isa = PBXBuildFile; productRef = 97AC071C2797704300752055 /* TwilioVerifyDemoCache */; };
+		97AC07252797764400752055 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AC07242797764400752055 /* NotificationService.swift */; };
+		97AC07292797764400752055 /* NotificationExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 97AC07222797764400752055 /* NotificationExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		97AC072F2797767600752055 /* TwilioVerifyDemoCache in Frameworks */ = {isa = PBXBuildFile; productRef = 97AC072E2797767600752055 /* TwilioVerifyDemoCache */; };
+		97AC07312797771700752055 /* TwilioVerifySDK in Frameworks */ = {isa = PBXBuildFile; productRef = 97AC07302797771700752055 /* TwilioVerifySDK */; };
 		8638059C2788DC4A00418FCC /* KeyChainAccessGroupHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8638059B2788DC4A00418FCC /* KeyChainAccessGroupHelper.swift */; };
 		97B7832C26F1005F0066CFD1 /* PushChallengePayloadData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97B7832B26F1005F0066CFD1 /* PushChallengePayloadData.swift */; };
 		97B7832E26F102F80066CFD1 /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97B7832D26F102F80066CFD1 /* AppModel.swift */; };
@@ -38,6 +43,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		97AC07272797764400752055 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F2AA37B7246F323C00B9388F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 97AC07212797764400752055;
+			remoteInfo = NotificationExtension;
+		};
 		F2AA37D6246F323F00B9388F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F2AA37B7246F323C00B9388F /* Project object */;
@@ -47,7 +59,25 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		97AC072D2797764400752055 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				97AC07292797764400752055 /* NotificationExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		9728E78627985D6800CC1CCA /* NotificationExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationExtension.entitlements; sourceTree = "<group>"; };
+		97AC07222797764400752055 /* NotificationExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		97AC07242797764400752055 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		97AC07262797764400752055 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8638059B2788DC4A00418FCC /* KeyChainAccessGroupHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainAccessGroupHelper.swift; sourceTree = "<group>"; };
 		97B7832B26F1005F0066CFD1 /* PushChallengePayloadData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushChallengePayloadData.swift; sourceTree = "<group>"; };
 		97B7832D26F102F80066CFD1 /* AppModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppModel.swift; sourceTree = "<group>"; };
@@ -87,11 +117,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		97AC071F2797764400752055 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				97AC07312797771700752055 /* TwilioVerifySDK in Frameworks */,
+				97AC072F2797767600752055 /* TwilioVerifyDemoCache in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F2AA37BC246F323C00B9388F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				860BB68C262A018A00E021C9 /* TwilioVerifySDK in Frameworks */,
+				97AC071D2797704300752055 /* TwilioVerifyDemoCache in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,6 +145,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		97AC07232797764400752055 /* NotificationExtension */ = {
+			isa = PBXGroup;
+			children = (
+				9728E78627985D6800CC1CCA /* NotificationExtension.entitlements */,
+				97AC07242797764400752055 /* NotificationService.swift */,
+				97AC07262797764400752055 /* Info.plist */,
+			);
+			path = NotificationExtension;
+			sourceTree = "<group>";
+		};
 		F24C243524B6143D00C1B92C /* ChallengeDetail */ = {
 			isa = PBXGroup;
 			children = (
@@ -215,6 +265,7 @@
 				F0C5C5E625BF17C8006CCD8E /* twilio-verify-ios */,
 				F2AA37C1246F323C00B9388F /* TwilioVerifyDemo */,
 				F2AA37D8246F323F00B9388F /* TwilioVerifyDemoTests */,
+				97AC07232797764400752055 /* NotificationExtension */,
 				F2AA37C0246F323C00B9388F /* Products */,
 				F2AA37E4246F325800B9388F /* Frameworks */,
 			);
@@ -227,6 +278,7 @@
 			children = (
 				F2AA37BF246F323C00B9388F /* TwilioVerifyDemo.app */,
 				F2AA37D5246F323F00B9388F /* TwilioVerifyDemoTests.xctest */,
+				97AC07222797764400752055 /* NotificationExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -320,6 +372,27 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		97AC07212797764400752055 /* NotificationExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 97AC072A2797764400752055 /* Build configuration list for PBXNativeTarget "NotificationExtension" */;
+			buildPhases = (
+				97AC071E2797764400752055 /* Sources */,
+				97AC071F2797764400752055 /* Frameworks */,
+				97AC07202797764400752055 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NotificationExtension;
+			packageProductDependencies = (
+				97AC072E2797767600752055 /* TwilioVerifyDemoCache */,
+				97AC07302797771700752055 /* TwilioVerifySDK */,
+			);
+			productName = NotificationExtension;
+			productReference = 97AC07222797764400752055 /* NotificationExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		F2AA37BE246F323C00B9388F /* TwilioVerifyDemo */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F2AA37DE246F323F00B9388F /* Build configuration list for PBXNativeTarget "TwilioVerifyDemo" */;
@@ -327,14 +400,17 @@
 				F2AA37BB246F323C00B9388F /* Sources */,
 				F2AA37BC246F323C00B9388F /* Frameworks */,
 				F2AA37BD246F323C00B9388F /* Resources */,
+				97AC072D2797764400752055 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				97AC07282797764400752055 /* PBXTargetDependency */,
 			);
 			name = TwilioVerifyDemo;
 			packageProductDependencies = (
 				860BB68B262A018A00E021C9 /* TwilioVerifySDK */,
+				97AC071C2797704300752055 /* TwilioVerifyDemoCache */,
 			);
 			productName = TwilioVerifyDemo;
 			productReference = F2AA37BF246F323C00B9388F /* TwilioVerifyDemo.app */;
@@ -364,10 +440,13 @@
 		F2AA37B7246F323C00B9388F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1140;
+				LastSwiftUpdateCheck = 1320;
 				LastUpgradeCheck = 1240;
 				ORGANIZATIONNAME = Twilio;
 				TargetAttributes = {
+					97AC07212797764400752055 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					F2AA37BE246F323C00B9388F = {
 						CreatedOnToolsVersion = 11.4.1;
 					};
@@ -392,11 +471,19 @@
 			targets = (
 				F2AA37BE246F323C00B9388F /* TwilioVerifyDemo */,
 				F2AA37D4246F323F00B9388F /* TwilioVerifyDemoTests */,
+				97AC07212797764400752055 /* NotificationExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		97AC07202797764400752055 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F2AA37BD246F323C00B9388F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -419,6 +506,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		97AC071E2797764400752055 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				97AC07252797764400752055 /* NotificationService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F2AA37BB246F323C00B9388F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -458,6 +553,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		97AC07282797764400752055 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 97AC07212797764400752055 /* NotificationExtension */;
+			targetProxy = 97AC07272797764400752055 /* PBXContainerItemProxy */;
+		};
 		F2AA37D7246F323F00B9388F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = F2AA37BE246F323C00B9388F /* TwilioVerifyDemo */;
@@ -485,6 +585,66 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		97AC072B2797764400752055 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_ENTITLEMENTS = NotificationExtension/NotificationExtension.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = NotificationExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = NotificationExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Twilio. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.TwilioVerifyDemo.NotificationService;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		97AC072C2797764400752055 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_ENTITLEMENTS = NotificationExtension/NotificationExtension.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = NotificationExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = NotificationExtension;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Twilio. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.TwilioVerifyDemo.NotificationService;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		F2AA37DC246F323F00B9388F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -608,6 +768,7 @@
 		F2AA37DF246F323F00B9388F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = TwilioVerifyDemo/TwilioVerifyDemo.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -631,9 +792,10 @@
 		F2AA37E0246F323F00B9388F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = TwilioVerifyDemo/TwilioVerifyDemo.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -657,7 +819,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9EVH78F4V4;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = TwilioVerifyDemoTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -678,7 +840,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9EVH78F4V4;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = TwilioVerifyDemoTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -696,6 +858,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		97AC072A2797764400752055 /* Build configuration list for PBXNativeTarget "NotificationExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				97AC072B2797764400752055 /* Debug */,
+				97AC072C2797764400752055 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F2AA37BA246F323C00B9388F /* Build configuration list for PBXProject "TwilioVerifyDemo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -727,6 +898,18 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		860BB68B262A018A00E021C9 /* TwilioVerifySDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TwilioVerifySDK;
+		};
+		97AC071C2797704300752055 /* TwilioVerifyDemoCache */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TwilioVerifyDemoCache;
+		};
+		97AC072E2797767600752055 /* TwilioVerifyDemoCache */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TwilioVerifyDemoCache;
+		};
+		97AC07302797771700752055 /* TwilioVerifySDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TwilioVerifySDK;
 		};

--- a/TwilioVerifyDemo/TwilioVerifyDemo.xcodeproj/xcshareddata/xcschemes/TwilioVerifyDemo.xcscheme
+++ b/TwilioVerifyDemo/TwilioVerifyDemo.xcodeproj/xcshareddata/xcschemes/TwilioVerifyDemo.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:TwilioVerifyDemo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "TwilioVerifyDemoCache"
+               BuildableName = "TwilioVerifyDemoCache"
+               BlueprintName = "TwilioVerifyDemoCache"
+               ReferencedContainer = "container:../TwilioVerifyDemoCache">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/TwilioVerifyDemo/TwilioVerifyDemo/ChallengeDetail/Presenter/ChallengeDetailPresenter.swift
+++ b/TwilioVerifyDemo/TwilioVerifyDemo/ChallengeDetail/Presenter/ChallengeDetailPresenter.swift
@@ -17,16 +17,17 @@
 
 import Foundation
 import TwilioVerifySDK
+import TwilioVerifyDemoCache
 
 protocol ChallengeDetailPresentable {
-  var challenge: Challenge! {get}
+  var challenge: AppChallenge! {get}
   func fetchChallengeDetails()
   func updateChallenge(withStatus status: ChallengeStatus)
 }
 
 class ChallengeDetailPresenter {
   
-  var challenge: Challenge! {
+  var challenge: AppChallenge! {
     didSet {
       view?.updateView()
     }
@@ -45,6 +46,13 @@ class ChallengeDetailPresenter {
     self.twilioVerify = twilioVerify
     self.challengeSid = challengeSid
     self.factorSid = factorSid
+    
+    // Call cache to check for pending challenges. (TwilioVerifyDemoCache)
+    if !ChallengesCache.storedChallenges.isEmpty {
+      print(ChallengesCache.storedChallenges)
+      // Delete cached factor: ChallengesCache.deleteStoredChallenge(ChallengesCache.storedChallenges[0])
+    }
+    
     fetchChallengeDetails()
   }
 }
@@ -53,7 +61,7 @@ extension ChallengeDetailPresenter: ChallengeDetailPresentable {
   func fetchChallengeDetails() {
     twilioVerify.getChallenge(challengeSid: challengeSid, factorSid: factorSid, success: { [weak self] challenge in
       guard let strongSelf = self else { return }
-      strongSelf.challenge = challenge
+      strongSelf.challenge = challenge.toAppChallenge()
     }) { [weak self] error in
       guard let strongSelf = self else { return }
       strongSelf.view?.showAlert(withMessage: error.errorMessage)

--- a/TwilioVerifyDemo/TwilioVerifyDemo/ChallengeDetail/View/ChallengeDetailViewController.swift
+++ b/TwilioVerifyDemo/TwilioVerifyDemo/ChallengeDetail/View/ChallengeDetailViewController.swift
@@ -18,7 +18,7 @@
 import UIKit
 import TwilioVerifySDK
 
-protocol ChallengeDetailView: class {
+protocol ChallengeDetailView: AnyObject {
   func updateView()
   func showAlert(withMessage message: String)
 }

--- a/TwilioVerifyDemoCache/.gitignore
+++ b/TwilioVerifyDemoCache/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/TwilioVerifyDemoCache/Package.swift
+++ b/TwilioVerifyDemoCache/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.4
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TwilioVerifyDemoCache",
+    defaultLocalization: "en",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        .library(
+            name: "TwilioVerifyDemoCache",
+            targets: ["TwilioVerifyDemoCache"]
+        )
+    ],
+    dependencies: [
+        .package(name: "TwilioVerifySDK", path: "../")
+    ],
+    targets: [
+        .target(
+            name: "TwilioVerifyDemoCache",
+            dependencies: [
+                .product(name: "TwilioVerifySDK", package: "TwilioVerifySDK")
+            ],
+            path: "Sources"
+        ),
+        .testTarget(
+            name: "TwilioVerifyDemoCacheTests",
+            dependencies: ["TwilioVerifyDemoCache"],
+            path: "Tests"
+        )
+    ]
+)

--- a/TwilioVerifyDemoCache/README.md
+++ b/TwilioVerifyDemoCache/README.md
@@ -1,0 +1,3 @@
+# TwilioVerifyDemoCache
+
+A description of this package.

--- a/TwilioVerifyDemoCache/Sources/CacheStorage.swift
+++ b/TwilioVerifyDemoCache/Sources/CacheStorage.swift
@@ -1,0 +1,83 @@
+//
+//  CacheStorage.swift
+//  TwilioVerifyDemoCache
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+protocol CacheStorageProtocol {
+    func delete(key: String)
+    func getAll<T: Codable>() -> [T]
+    func get<T: Codable>(key: String) -> T?
+    func set<T: Codable>(key: String, value: T)
+}
+
+/**
+ This class is meant for sharing data between
+ the app and the notification extension.
+ This class is not required for your SDK implementation.
+ */
+final class CacheStorage {
+    // MARK: - Properties
+    private lazy var jsonDecoder = JSONDecoder()
+    private lazy var jsonEncoder = JSONEncoder()
+    private lazy var provider = UserDefaults(
+        suiteName: "group.twilio.TwilioVerifyDemo"
+    )
+}
+
+// MARK: - DemoStorageProtocol
+extension CacheStorage: CacheStorageProtocol {
+    func getAll<T: Codable>() -> [T] {
+        let allValues = provider?.dictionaryRepresentation().compactMap {
+            $0.value as? Data
+        } ?? []
+        
+        do {
+            return try allValues.compactMap {
+                try jsonDecoder.decode(T.self, from: $0)
+            }
+        } catch {
+            print(error.localizedDescription)
+            return []
+        }
+    }
+    
+    func get<T: Codable>(key: String) -> T? {
+        guard let data = provider?.data(forKey: key) else {
+            return nil
+        }
+        
+        do {
+            return try jsonDecoder.decode(T.self, from: data)
+        } catch {
+            print(error.localizedDescription)
+            return nil
+        }
+    }
+    
+    func delete(key: String) {
+        provider?.removeObject(forKey: key)
+    }
+    
+    func set<T: Codable>(key: String, value: T) {
+        do {
+            let data = try jsonEncoder.encode(value)
+            provider?.set(data, forKey: key)
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+}

--- a/TwilioVerifyDemoCache/Sources/ChallengesCache.swift
+++ b/TwilioVerifyDemoCache/Sources/ChallengesCache.swift
@@ -1,0 +1,41 @@
+//
+//  ChallengesCache.swift
+//  TwilioVerifyDemoCache
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/**
+ This class is meant for sharing data between
+ the app and the notification extension.
+ This class is not required for your SDK implementation.
+ */
+public class ChallengesCache {
+    private static let cacheStorage: CacheStorageProtocol = CacheStorage()
+    
+    private init() {}
+    
+    public static var storedChallenges: [AppChallenge] {
+        cacheStorage.getAll()
+    }
+    
+    public static func save(challenge: AppChallenge) {
+        cacheStorage.set(key: challenge.sid, value: challenge)
+    }
+    
+    public static func deleteStoredChallenge(_ challenge: AppChallenge) {
+        cacheStorage.delete(key: challenge.sid)
+    }
+}

--- a/TwilioVerifyDemoCache/Sources/Extensions/Factor+Extensions.swift
+++ b/TwilioVerifyDemoCache/Sources/Extensions/Factor+Extensions.swift
@@ -1,0 +1,42 @@
+//
+//  Factor+Extensions.swift
+//  TwilioVerifyDemoCache
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import TwilioVerifySDK
+
+public extension Challenge {
+    func toAppChallenge() -> AppChallenge {
+        AppChallenge(
+            sid: sid,
+            challengeDetails: AppChallengeDetails(
+                message: challengeDetails.message,
+                fields: challengeDetails.fields.map {
+                    AppChallengeDetailField(
+                        label: $0.label,
+                        value: $0.value
+                    )
+                }
+            ),
+            hiddenDetails: hiddenDetails,
+            factorSid: factorSid,
+            status: AppChallengeStatus(
+                rawValue: status.rawValue
+            ) ?? .undefined,
+            updatedAt: updatedAt,
+            expirationDate: expirationDate
+        )
+    }
+}

--- a/TwilioVerifyDemoCache/Sources/Models/AppChallenge.swift
+++ b/TwilioVerifyDemoCache/Sources/Models/AppChallenge.swift
@@ -1,0 +1,82 @@
+//
+//  AppChallenge.swift
+//  TwilioVerifyDemoCache
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/**
+ This struct is meant for sharing data between
+ the app and the notification extension.
+ This class is not required for your SDK implementation.
+ */
+public struct AppChallenge: Codable {
+    public let sid: String
+    public let challengeDetails: AppChallengeDetails
+    public let hiddenDetails: [String: String]?
+    public let factorSid: String
+    public let status: AppChallengeStatus
+    public let updatedAt: Date
+    public let expirationDate: Date
+    
+    public init(
+        sid: String,
+        challengeDetails: AppChallengeDetails,
+        hiddenDetails: [String: String]?,
+        factorSid: String,
+        status: AppChallengeStatus,
+        updatedAt: Date,
+        expirationDate: Date
+    ) {
+        self.sid = sid
+        self.challengeDetails = challengeDetails
+        self.hiddenDetails = hiddenDetails
+        self.factorSid = factorSid
+        self.status = status
+        self.updatedAt = updatedAt
+        self.expirationDate = expirationDate
+    }
+}
+
+public enum AppChallengeStatus: String, Codable {
+    case pending
+    case approved
+    case denied
+    case expired
+    case undefined
+}
+
+public struct AppChallengeDetails: Codable {
+    public let message: String
+    public let fields: [AppChallengeDetailField]
+    
+    public init(
+        message: String,
+        fields: [AppChallengeDetailField]
+    ) {
+        self.message = message
+        self.fields = fields
+    }
+}
+
+public struct AppChallengeDetailField: Codable {
+    public let label: String
+    public let value: String
+    
+    public init(label: String, value: String) {
+        self.label = label
+        self.value = value
+    }
+}

--- a/TwilioVerifyDemoCache/Tests/TwilioVerifyDemoCacheTests.swift
+++ b/TwilioVerifyDemoCache/Tests/TwilioVerifyDemoCacheTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import TwilioVerifyDemoCache
+
+final class TwilioVerifyDemoCacheTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(TwilioVerifyDemoCache().text, "Hello, World!")
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Twilio Verify. Please consider this template for your PR -->
<!-- Title format: [Ticket Number/Issue Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (task, bug, housekeeping, etc) -->


<!-- Ticket: Please add the ticket number or the Github issue number according to your case -->
## Ticket
- [23686]

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->
## Description
- `TwilioVerifyDemoCache` package created in order to share data between Notification extension and Demo app.
- Notification Extension created in order to test implementation
- Demo app updated in order to support custom Factor model

<!-- Screenshot: When possible add a screenshot or gif showing your changes if not you can remove this section -->
## Screenshot

<!-- Testing: Please check all that apply -->
## Testing
- [ ] Added unit tests
- [x] Ran unit tests successfully
- [ ] Added documentation for public APIs and/or Wiki
