### PR TITLE
[23665] - Store & Show Challenge using the NotificationService extension.

### DIFF
--- a/TwilioVerifyDemo/TwilioVerifyDemo.xcodeproj/project.pbxproj
+++ b/TwilioVerifyDemo/TwilioVerifyDemo.xcodeproj/project.pbxproj
@@ -8,12 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		860BB68C262A018A00E021C9 /* TwilioVerifySDK in Frameworks */ = {isa = PBXBuildFile; productRef = 860BB68B262A018A00E021C9 /* TwilioVerifySDK */; };
+		8638059C2788DC4A00418FCC /* KeyChainAccessGroupHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8638059B2788DC4A00418FCC /* KeyChainAccessGroupHelper.swift */; };
 		97AC071D2797704300752055 /* TwilioVerifyDemoCache in Frameworks */ = {isa = PBXBuildFile; productRef = 97AC071C2797704300752055 /* TwilioVerifyDemoCache */; };
 		97AC07252797764400752055 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AC07242797764400752055 /* NotificationService.swift */; };
 		97AC07292797764400752055 /* NotificationExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 97AC07222797764400752055 /* NotificationExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		97AC072F2797767600752055 /* TwilioVerifyDemoCache in Frameworks */ = {isa = PBXBuildFile; productRef = 97AC072E2797767600752055 /* TwilioVerifyDemoCache */; };
 		97AC07312797771700752055 /* TwilioVerifySDK in Frameworks */ = {isa = PBXBuildFile; productRef = 97AC07302797771700752055 /* TwilioVerifySDK */; };
-		8638059C2788DC4A00418FCC /* KeyChainAccessGroupHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8638059B2788DC4A00418FCC /* KeyChainAccessGroupHelper.swift */; };
 		97B7832C26F1005F0066CFD1 /* PushChallengePayloadData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97B7832B26F1005F0066CFD1 /* PushChallengePayloadData.swift */; };
 		97B7832E26F102F80066CFD1 /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97B7832D26F102F80066CFD1 /* AppModel.swift */; };
 		F07CAEAD25A79D1300CA5CB0 /* DIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07CAEAC25A79D1300CA5CB0 /* DIContainer.swift */; };
@@ -74,11 +74,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		8638059B2788DC4A00418FCC /* KeyChainAccessGroupHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainAccessGroupHelper.swift; sourceTree = "<group>"; };
 		9728E78627985D6800CC1CCA /* NotificationExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationExtension.entitlements; sourceTree = "<group>"; };
 		97AC07222797764400752055 /* NotificationExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		97AC07242797764400752055 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		97AC07262797764400752055 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8638059B2788DC4A00418FCC /* KeyChainAccessGroupHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainAccessGroupHelper.swift; sourceTree = "<group>"; };
 		97B7832B26F1005F0066CFD1 /* PushChallengePayloadData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushChallengePayloadData.swift; sourceTree = "<group>"; };
 		97B7832D26F102F80066CFD1 /* AppModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppModel.swift; sourceTree = "<group>"; };
 		F07CAEAC25A79D1300CA5CB0 /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };

--- a/TwilioVerifyDemo/TwilioVerifyDemo/ChallengeDetail/View/ChallengeDetailViewController.swift
+++ b/TwilioVerifyDemo/TwilioVerifyDemo/ChallengeDetail/View/ChallengeDetailViewController.swift
@@ -43,6 +43,7 @@ class ChallengeDetailViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     setupUI()
+    presenter?.loadChallenge()
   }
   
   override func viewWillAppear(_ animated: Bool) {

--- a/TwilioVerifyDemo/TwilioVerifyDemo/TwilioVerify/TwilioVerifyAdapter.swift
+++ b/TwilioVerifyDemo/TwilioVerifyDemo/TwilioVerify/TwilioVerifyAdapter.swift
@@ -31,10 +31,7 @@ class TwilioVerifyAdapter {
     #if DEBUG
       builder = builder.enableDefaultLoggingService(withLevel: .all)
     #endif
-    twilioVerify = try builder
-      .setAccessGroup(Constants.accessGroup)
-      .setSynchronizableStorage(true)
-      .build()
+    twilioVerify = try builder.build()
   }
 }
 

--- a/TwilioVerifySDK/TwilioVerify/Sources/Data/Storage.swift
+++ b/TwilioVerifySDK/TwilioVerify/Sources/Data/Storage.swift
@@ -87,12 +87,23 @@ extension Storage: StorageProvider {
 }
 
 private extension Storage {
+  var isAppExtension: Bool {
+    return Bundle.main.bundlePath.hasSuffix(".appex")
+  }
+
   func checkMigrations(_ migrations: [Migration], clearStorageOnReinstall: Bool) throws {
+    if isAppExtension {
+      NSLog("Migrations are not available for app extensions.")
+      return
+    }
+
     var currentVersion = userDefaults.integer(forKey: Constants.currentVersionKey)
     guard currentVersion < version else {
       return
     }
+
     let previousClearStorageOnReinstall = previousClearStorageOnReinstallValue()
+
     if currentVersion == Constants.noVersion && clearStorageOnReinstall && previousClearStorageOnReinstall != nil {
       try? clearItemsWithoutService()
       try clear()
@@ -100,6 +111,7 @@ private extension Storage {
       updateClearStorageOnReinstall(value: clearStorageOnReinstall)
       return
     }
+
     for migration in migrations {
       if migration.startVersion < currentVersion {
         continue
@@ -110,6 +122,7 @@ private extension Storage {
         break
       }
     }
+
     updateVersion(version: version)
     updateClearStorageOnReinstall(value: clearStorageOnReinstall)
   }


### PR DESCRIPTION
<!-- Ticket: Please add the ticket number or the Github issue number according to your case -->
## Ticket
- [23665]
- [23687]

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->
## Description
- Store & Show Challenge using the NotificationService extension.

<!-- Commit message: This repository uses a commit message convention https://docs.google.com/document/d/19ed9FHIAlJwlGzf3xacgE15MVfTwx8n9G2QeYyCr-5E/edit?usp=drive_web&ouid=116864038767072405931 set the commit message to be used when merging this PR e.g. docs: add architecture diagrams [99999] -->
## Commit message
- 

<!-- Screenshot: When possible add a screenshot or gif showing your changes if not you can remove this section -->
## Screenshot

https://user-images.githubusercontent.com/4898461/151061482-5ea1b39a-1523-4aa4-b74d-101e1c3c20da.MP4

The video showcase the following scenarios:
1. The store of a challenge using the NotificationService extension & showing a challenged pre-processed & stored in the app. During background.
2. The store of a challenge using the NotificationService extension & showing a challenged pre-processed & stored in the app. During foreground.
3. The current management of multiple push notifications for the same challenge, the first time it will load using the cache, but after it will require the fetch, since we are deleting that information once we display the information for first time.

<!-- Testing: Please check all that apply -->
## Testing
- [ ] Added unit tests
- [ ] Ran unit tests successfully
- [ ] Added documentation for public APIs and/or Wiki
